### PR TITLE
bugfix: flag should be 'type' for filtering by flow type

### DIFF
--- a/build/gc/cmd/flows/flows.go
+++ b/build/gc/cmd/flows/flows.go
@@ -106,7 +106,7 @@ func Cmdflows() *cobra.Command {
 }`)
 	flowsCmd.AddCommand(getCmd)
 
-	utils.AddFlag(listCmd.Flags(), "[]string", "varType", "", "Type Valid values: bot, commonmodule, digitalbot, inboundcall, inboundchat, inboundemail, inboundshortmessage, outboundcall, inqueuecall, inqueueemail, inqueueshortmessage, speech, securecall, surveyinvite, voice, voicemail, workflow, workitem")
+	utils.AddFlag(listCmd.Flags(), "[]string", "type", "", "Type Valid values: bot, commonmodule, digitalbot, inboundcall, inboundchat, inboundemail, inboundshortmessage, outboundcall, inqueuecall, inqueueemail, inqueueshortmessage, speech, securecall, surveyinvite, voice, voicemail, workflow, workitem")
 	utils.AddFlag(listCmd.Flags(), "int", "pageNumber", "1", "Page number")
 	utils.AddFlag(listCmd.Flags(), "int", "pageSize", "25", "Page size")
 	utils.AddFlag(listCmd.Flags(), "string", "sortBy", "id", "Sort by")


### PR DESCRIPTION
EDIT: SORRY, NOT A BUG 😅
-------------------------
Hello

I think I might have discovered a bug, in the command `gc flows list`.

Currently in the CLI, the flag for filtering by flow type is `--varType`. But it does not work. Shouldn't it be just `--type`? As the query parameter in `GET /api/v2/flows` is `type`...